### PR TITLE
Fix major bugs in `update_reference`. 

### DIFF
--- a/exoatlas/populations/Population.py
+++ b/exoatlas/populations/Population.py
@@ -148,7 +148,6 @@ class Population(Talker):
         # define some cleaned names and hostnames, for indexing
         try:
             self.standard["tidyname"]
-            print("tidyname was not found, creating it!")
         except KeyError:
             self.standard["tidyname"] = [
                 clean(x).lower() for x in self.standard["name"]

--- a/exoatlas/populations/Population.py
+++ b/exoatlas/populations/Population.py
@@ -102,7 +102,7 @@ class Population(Talker):
     # kludge?
     _pithy = True
 
-    def __init__(self, standard, label="unknown", **plotkw):
+    def __init__(self, standard, label=None, **plotkw):
         """
         Initialize a Population of exoplanets from a standardized table.
 
@@ -429,13 +429,13 @@ class Population(Talker):
         # use a (list of) string(s) to index population by name
         if isinstance(key, str):
             # is it just one name?
-            key = clean(key).lower()
+            tidy = clean(key).lower()
         elif isinstance(key[0], str):
             # is it a list of names?
-            key = [clean(k).lower() for k in key]
+            tidy = [clean(k).lower() for k in key]
 
         # pull out rows by planet name
-        subset = self.standard.loc["tidyname", key]
+        subset = self.standard.loc["tidyname", tidy]
 
         # create a useful label for the population
         if isinstance(key, str):
@@ -471,13 +471,13 @@ class Population(Talker):
         # use a string or a list of strings to index the population by name
         if isinstance(key, str):
             # is it just one name?
-            key = clean(key).lower()
+            tidy = clean(key).lower()
         elif isinstance(key[0], str):
             # is it a list of names?
-            key = [clean(k).lower() for k in key]
+            tidy = [clean(k).lower() for k in key]
 
         # pull out rows by planet name
-        subset = self.standard.loc["tidyhostname", key]
+        subset = self.standard.loc["tidyhostname", tidy]
 
         # create a useful label for the population
         if isinstance(key, str):

--- a/exoatlas/populations/curation/transiting_exoplanets.py
+++ b/exoatlas/populations/curation/transiting_exoplanets.py
@@ -1,2 +1,0 @@
-def curate(pop):
-    pass

--- a/exoatlas/populations/exoplanets/exoplanets.py
+++ b/exoatlas/populations/exoplanets/exoplanets.py
@@ -930,8 +930,8 @@ class Exoplanets(ExoplanetsPSCP):
                     ]
                 )
             except KeyError:
-                if verbose:
-                    print(f'No reference(s) "{references}" found for key "{k}"')
+                # if verbose:
+                #    print(f'No reference(s) "{references}" found for key "{k}"')
                 continue
 
             # extract a (possibly even smaller) table of just these planets, or give up
@@ -948,26 +948,48 @@ class Exoplanets(ExoplanetsPSCP):
 
             # find where there is a real new measurement for this key
             is_finite = np.isfinite(these_planets[f"{k}"])
-            if verbose:
-                print(
-                    k,
-                    planets_to_index,
-                    is_finite,
-                    type(is_finite).__name__,
-                    (type(these_planets).__name__),
-                )
+            # if verbose:
+            #    print(
+            #        k,
+            #        planets_to_index,
+            #        is_finite,
+            #        type(is_finite).__name__,
+            #        (type(these_planets).__name__),
+            #    )
             new = these_planets[is_finite]
+
+            # if verbose:
+            #    print("The new properties to be adopted:")
+            #    display(new)
 
             # construct a new table of the references we want to update for this key
             if len(new) > 0:
                 for tidyname in np.unique(new["tidyname"]):
-                    old = self.standard.loc["tidyname", tidyname]
                     if verbose:
-                        old_for_display = copy.deepcopy(old)
+                        print(f"'{k}' for '{tidyname}'")
+                    old_for_this_planet = self.standard.loc["tidyname", tidyname]
+                    new_for_this_planet = new.loc["tidyname", tidyname]
+                    # if verbose:
+                    # print("old", old_for_this_planet["tidyname"])
+                    # print("new", new_for_this_planet["tidyname"])
+                    assert (
+                        old_for_this_planet["tidyname"]
+                        == new_for_this_planet["tidyname"]
+                    )
+
                     keys_to_display = ["tidyname"]
+                    if verbose:
+                        old_for_display = copy.deepcopy(old_for_this_planet)
+
                     for s in suffixes:
                         try:
-                            old[f"{k}{s}"] = new[f"{k}{s}"][0]
+                            if verbose:
+                                old_value = old_for_this_planet[f"{k}{s}"]
+                                new_value = new_for_this_planet[f"{k}{s}"]
+                                # print(f"{k}{s}: {old_value} > {new_value}")
+                            old_for_this_planet[f"{k}{s}"] = new_for_this_planet[
+                                f"{k}{s}"
+                            ]
                             keys_to_display.append(f"{k}{s}")
                         except (IndexError, KeyError):
                             pass
@@ -975,7 +997,7 @@ class Exoplanets(ExoplanetsPSCP):
                         change_summary = vstack(
                             [
                                 old_for_display[keys_to_display],
-                                new[keys_to_display][0],
+                                new_for_this_planet[keys_to_display],
                             ]
                         )
                         change_summary.add_column(

--- a/exoatlas/populations/exoplanets/exoplanets.py
+++ b/exoatlas/populations/exoplanets/exoplanets.py
@@ -923,6 +923,7 @@ class Exoplanets(ExoplanetsPSCP):
 
             # extract a table of just these references, or give up
             try:
+                # print(f"{k}_reference", references)
                 these_references = QTable(
                     self.individual_references.standard.loc[
                         f"{k}_reference", references
@@ -972,7 +973,10 @@ class Exoplanets(ExoplanetsPSCP):
                             pass
                     if verbose:
                         change_summary = vstack(
-                            [old_for_display[keys_to_display], new[keys_to_display][0]]
+                            [
+                                old_for_display[keys_to_display],
+                                new[keys_to_display][0],
+                            ]
                         )
                         change_summary.add_column(
                             ["old", "new"], index=0, name="version"

--- a/exoatlas/populations/exoplanets/transiting_exoplanets.py
+++ b/exoatlas/populations/exoplanets/transiting_exoplanets.py
@@ -13,7 +13,8 @@ class TransitingExoplanets(Exoplanets):
         Exoplanets.__init__(self, **kw)
 
         # set the label
-        self.label = "Transiting Exoplanets"
+        if "label" not in kw:
+            self.label = "Transiting Exoplanets"
 
         # tidy up this population
         self.remove_nontransiting()

--- a/exoatlas/populations/exoplanets/transiting_exoplanets.py
+++ b/exoatlas/populations/exoplanets/transiting_exoplanets.py
@@ -4,7 +4,6 @@ Define a subset of all exoplanets for only those known to transit.
 
 from ...imports import *
 from .exoplanets import *
-from ..curation.transiting_exoplanets import curate
 
 __all__ = ["TransitingExoplanets"]
 
@@ -16,19 +15,8 @@ class TransitingExoplanets(Exoplanets):
         # set the label
         self.label = "Transiting Exoplanets"
 
-        # remove non-transiting
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=RuntimeWarning)
-            ok_transit = self.detected_in_transit == 1
-            has_no_radius = np.isnan(self.radius)
-
-        # apply any planet-specific curation to the population
-        curate(self)
-
         # tidy up this population
         self.remove_nontransiting()
-        self.remove_bad_radii()
-        self.tidy_eccentricities()
 
     def remove_nontransiting(self):
         """
@@ -40,71 +28,3 @@ class TransitingExoplanets(Exoplanets):
         """
         ok = self.detected_in_transit == 1
         self.standard = self.standard[ok]
-
-    def remove_bad_radii(self):
-        """
-        Remove planets with bad radii.
-
-        Returns
-        -------
-        (modifies the input population in place, but returns nothing)
-        """
-
-        self.speak("Trying to remove bad radii.")
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=RuntimeWarning)
-            has_no_radius = np.isnan(self.radius)
-            upper_limit_on_radius = 30 * u.Rearth
-            ok = (self.radius < upper_limit_on_radius) | has_no_radius
-            bad = ok == False
-
-        N = sum(bad)
-        s = ", ".join(self.name[bad])
-        self.speak(
-            f"""
-        {N} planets had non-existent radii, or radii larger
-        than {upper_limit_on_radius}. Let's assume those are bad.
-        """
-        )
-        if N > 0:
-            self.speak(f"The affected planets are {s}")
-
-        self.standard = self.standard[ok]
-
-    def tidy_eccentricities(self):
-        """
-        Often in the exoplanet archive, a planet with e!=0 is in fact an
-        upper limit. We make the (probably a little too bold) assumption
-        that if an eccentricity has actually been determined for a planet
-        then it will also have finite omega. Therefore, we'll call everything
-        that has an eccentricity but no omega an upper limit and force it
-        to zero. FIXME -- we should handle this more responsibly in the future!
-
-        Returns
-        -------
-        (modifies the input population in place, but returns nothing)
-        """
-
-        self.speak("Trying to tidy the eccentricities.")
-
-        # figure out which e's are troublesome
-        finite_e = self.e > 0
-        no_omega = np.isfinite(self.omega) == False
-        is_probably_upper_limit = finite_e & no_omega
-
-        N = sum(is_probably_upper_limit)
-        s = ", ".join(self.name[is_probably_upper_limit])
-        self.speak(
-            f"""
-        {N} eccentricities were finite but had no omega.
-        Let's assume those are upper limits and set e=0
-        for all of them.
-        """
-        )
-
-        if N > 0:
-            self.speak(f"The affected planets are {s}")
-
-        # force those ones to zero
-        self.standard["eccentricity"][is_probably_upper_limit] = 0

--- a/exoatlas/version.py
+++ b/exoatlas/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 
 def version():

--- a/exoatlas/visualizations/buildable.py
+++ b/exoatlas/visualizations/buildable.py
@@ -75,7 +75,7 @@ class physical_summary(BuildablePlot):
         fr.ticks_simplify_exponents("y")
         fr.add_teqaxis()
         if len(pops) > 1:
-            fr.add_legend(frameon=False)
+            fr.add_legend(frameon=False, bbox_to_anchor=(1, 1), loc="lower left")
         fr.remove_ylabel()
 
         mr = MassRadius()


### PR DESCRIPTION
There was a huge problem in how `update_reference` tried to overwrite default planet parameter values using those from a specific paper. I tracked it down to some unexpected behavior in `Table` indexing, especially when tables got sliced multiple times and the attached indices were trying to propagate backward through multiple larger tables. I *think* I fixed it by resetting table indices `tidyname` and `tidyhostname` every time a new `Population` gets created. 

This pull request:
- fixes indexing problems that made it impossible to update references
- fixed another associated bug where papers with parameter for multiple planets wouldn't overwrite correctly
- updates to version 0.4.1
- 