### PR TITLE
small tweaks for `exoatlas` poster

### DIFF
--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -1,241 +1,241 @@
 {
-    "cells": [
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "# Quickstart\n",
-                "Let's take a brief whirlwind tour of some of the basic tools in `exoatlas`. Most of the concepts seen here are decribed in more detail later, but hopefully this is enough for you to get started!"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "import exoatlas as ea\n",
-                "import exoatlas.visualizations as vi\n",
-                "import astropy.units as u \n",
-                "\n",
-                "ea.version()"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "## 🌌 Make Populations of Planets\n",
-                "\n",
-                "`exoatlas` can create objects containing properties for large samples of planets. Solar System planets come from [JPL Solar System Dynamics](https://ssd.jpl.nasa.gov), and exoplanets come from the [NASA Exoplanet Archive](https://exoplanetarchive.ipac.caltech.edu)."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "solar = ea.SolarSystem()\n",
-                "solar"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "exoplanets = ea.Exoplanets() \n",
-                "exoplanets"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "## 🧮 Extract Quantities and Uncertainties\n",
-                "\n",
-                "For a population, `exoatlas` can provide easy access to archival table columns and their uncertainties. All quantities have [`astropy.units`](https://docs.astropy.org/en/stable/units/index.html) attached to them, to minimize confusion about unit conversion."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "exoplanets.mass()"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "exoplanets.mass_uncertainty()"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "`exoatlas` can also calculate derived quantities and use [`astropy.uncertainty`](https://docs.astropy.org/en/stable/uncertainty/index.html) to propagate uncertainties for those derived quantities. "
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "exoplanets.insolation()"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "exoplanets.insolation_uncertainty()"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "exoplanets.insolation_uncertainty()/exoplanets.insolation()"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "## ⚗️ Filter Populations by Properties\n",
-                "\n",
-                "`exoatlas` can extract subsets of populations, selecting planets just in a specific range of interest for particular properties. These subsets have all the same powers as their parent populations. By setting attributes for these subset populations, we can affect how they'll be visualized."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "nearby = exoplanets[exoplanets.distance() < 30*u.pc]\n",
-                "nearby.label = 'Nearby'\n",
-                "nearby.color = 'coral'\n",
-                "nearby.marker = 'P'\n",
-                "nearby.size = 20\n",
-                "nearby"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "easy = exoplanets[exoplanets.transmission_snr(telescope='JWST', wavelength=4*u.micron) > 10]\n",
-                "easy.label = 'Easy'\n",
-                "easy.color='orchid'\n",
-                "easy.marker='*'\n",
-                "easy.outlined=True \n",
-                "easy.filled=False \n",
-                "easy.size=100\n",
-                "easy.annotate_planets = True\n",
-                "easy"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "first = exoplanets['HD209458b']\n",
-                "first.size = 500\n",
-                "first.color = 'magenta'\n",
-                "first"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "## 🎨 Visualize Populations Together \n",
-                "\n",
-                "`exoatlas` provides some built-in visualizations, as well as a framework for constructing new plots that can easily compare multiple populations to each other."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "ps = vi.PlanetGallery()\n",
-                "ps.build([solar, exoplanets, nearby, easy, first])\n"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "Gosh, what a complicated plot! But at least it demonstrates lots of ways of visualizing populations!"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "## 📓 Create Tables\n",
-                "\n",
-                "`exoatlas` can save populations out into tables, for whatever other purposes you want!"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "easy.create_planning_table()"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "## 🎉 and more...\n",
-                "\n",
-                "Please explore the rest of the documentation to learn if/how you can use `exoatlas` to help with your research or teaching or learning!"
-            ]
-        }
-    ],
-    "metadata": {
-        "kernelspec": {
-            "display_name": "exoatlas",
-            "language": "python",
-            "name": "python3"
-        },
-        "language_info": {
-            "codemirror_mode": {
-                "name": "ipython",
-                "version": 3
-            },
-            "file_extension": ".py",
-            "mimetype": "text/x-python",
-            "name": "python",
-            "nbconvert_exporter": "python",
-            "pygments_lexer": "ipython3",
-            "version": "3.13.2"
-        }
-    },
-    "nbformat": 4,
-    "nbformat_minor": 2
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Quickstart\n",
+    "Let's take a brief whirlwind tour of some of the basic tools in `exoatlas`. Most of the concepts seen here are decribed in more detail later, but hopefully this is enough for you to get started!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import exoatlas as ea\n",
+    "import exoatlas.visualizations as vi\n",
+    "import astropy.units as u \n",
+    "\n",
+    "ea.version()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 🌌 Make Populations of Planets\n",
+    "\n",
+    "`exoatlas` can create objects containing properties for large samples of planets. Solar System planets come from [JPL Solar System Dynamics](https://ssd.jpl.nasa.gov), and exoplanets come from the [NASA Exoplanet Archive](https://exoplanetarchive.ipac.caltech.edu)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "solar = ea.SolarSystem()\n",
+    "solar"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exoplanets = ea.Exoplanets() \n",
+    "exoplanets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 🧮 Extract Quantities and Uncertainties\n",
+    "\n",
+    "For a population, `exoatlas` can provide easy access to archival table columns and their uncertainties. All quantities have [`astropy.units`](https://docs.astropy.org/en/stable/units/index.html) attached to them, to minimize confusion about unit conversion."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exoplanets.mass()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exoplanets.mass_uncertainty()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`exoatlas` can also calculate derived quantities and use [`astropy.uncertainty`](https://docs.astropy.org/en/stable/uncertainty/index.html) to propagate uncertainties for those derived quantities. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exoplanets.insolation()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exoplanets.insolation_uncertainty()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exoplanets.insolation_uncertainty()/exoplanets.insolation()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## ⚗️ Filter Populations by Properties\n",
+    "\n",
+    "`exoatlas` can extract subsets of populations, selecting planets just in a specific range of interest for particular properties. These subsets have all the same powers as their parent populations. By setting attributes for these subset populations, we can affect how they'll be visualized."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nearby = exoplanets[exoplanets.distance() < 30*u.pc]\n",
+    "nearby.label = 'Nearby'\n",
+    "nearby.color = 'coral'\n",
+    "nearby.marker = 'P'\n",
+    "nearby.size = 20\n",
+    "nearby"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "easy = exoplanets[exoplanets.transmission_snr(telescope='JWST', wavelength=4*u.micron) > 10]\n",
+    "easy.label = 'Easy'\n",
+    "easy.color='orchid'\n",
+    "easy.marker='*'\n",
+    "easy.outlined=True \n",
+    "easy.filled=False \n",
+    "easy.size=100\n",
+    "easy.annotate_planets = True\n",
+    "easy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "first = exoplanets['HD209458b']\n",
+    "first.size = 500\n",
+    "first.color = 'magenta'\n",
+    "first"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 🎨 Visualize Populations Together \n",
+    "\n",
+    "`exoatlas` provides some built-in visualizations, as well as a framework for constructing new plots that can easily compare multiple populations to each other."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ps = vi.PlanetGallery()\n",
+    "ps.build([solar, exoplanets, nearby, easy, first])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Gosh, what a complicated plot! But at least it demonstrates lots of ways of visualizing populations!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 📓 Create Tables\n",
+    "\n",
+    "`exoatlas` can save populations out into tables, for whatever other purposes you want!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "easy.create_planning_table()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 🎉 and more...\n",
+    "\n",
+    "Please explore the rest of the documentation to learn if/how you can use `exoatlas` to help with your research or teaching or learning!"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "exoatlas",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/docs/visualizing.ipynb
+++ b/docs/visualizing.ipynb
@@ -584,7 +584,7 @@
             "cell_type": "markdown",
             "metadata": {},
             "source": [
-                "Arbitrarily complicated custom `Gallery` definitions can be created by overwriting the `.setup_maps` and `.refine_maps` methods."
+                "Arbitrarily complicated custom `Gallery` definitions can be created by overwriting the `.setup_maps` and `.refine_maps` methods. That's how `PlanetGallery` and `EverythingGallery` were made!"
             ]
         },
         {
@@ -594,6 +594,17 @@
             "outputs": [],
             "source": [
                 "vi.PlanetGallery().build([solar, exoplanets, neat_planet])"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "all_planets = ea.get_all_planets()\n",
+                "all_planets['neat'] = neat_planet\n",
+                "vi.EverythingGallery().build(all_planets)"
             ]
         },
         {

--- a/exoatlas/populations/collections.py
+++ b/exoatlas/populations/collections.py
@@ -9,6 +9,15 @@ from .exoplanets import *
 from .solarsystem import *
 
 
+def get_transiting_and_nontransiting_exoplanets():
+    e = Exoplanets()
+    transit = e[e.detected_in_transit() != 0]
+    transit.label = "Transiting Exoplanets"
+    nontransit = e[e.detected_in_transit() == 0]
+    nontransit.label = "Non-transiting Exoplanets"
+    return dict(nontransit=nontransit, transit=transit)
+
+
 def get_exoplanets_by_method(methods="all", include_solar_system=True):
     """
     Create a dictionary that contains a collection of exoplanet
@@ -44,7 +53,7 @@ def get_exoplanets_by_method(methods="all", include_solar_system=True):
     return pops
 
 
-def get_all_solar_system_objects():
+def get_solar_system_objects():
     """
     Create a dictionary that contains a collection of
     Solar System populations, grouped by category.
@@ -58,8 +67,8 @@ def get_all_solar_system_objects():
     pops = dict(
         major=SolarSystem(),
         dwarf=SolarSystemDwarfPlanets(),
-        minor=SolarSystemMinorPlanets(),
         moons=SolarSystemMoons(),
+        minor=SolarSystemMinorPlanets(),
     )
     return pops
 
@@ -129,3 +138,12 @@ def get_exoplanets_by_teff():
     items = list(pops.items())
     items.reverse()
     return dict(items)
+
+
+def get_all_planets():
+    p = get_transiting_and_nontransiting_exoplanets() | get_solar_system_objects()
+    p["transit"].color = "black"
+    p["nontransit"].color = "coral"
+    p["major"].annotate_planets = True
+    p["dwarf"].annotate_planets = True
+    return p

--- a/exoatlas/populations/exoplanets/exoplanets.py
+++ b/exoatlas/populations/exoplanets/exoplanets.py
@@ -690,7 +690,7 @@ class Exoplanets(ExoplanetsPSCP):
         # kind of kludgy, to enforce different colors
         subset._plotkw["color"] = None
         subset._plotkw["c"] = None
-
+        subset._plotkw["zorder"] = subset._plotkw.get("zorder", 1) + 1
         return subset
 
     def load_individual_references(self):

--- a/exoatlas/populations/population_core.py
+++ b/exoatlas/populations/population_core.py
@@ -643,6 +643,7 @@ class Population:
         # kind of kludgy, to enforce different colors
         subset._plotkw["color"] = None
         subset._plotkw["c"] = None
+        subset._plotkw["zorder"] = subset._plotkw.get("zorder", 1) + 1
 
         return subset
 

--- a/exoatlas/populations/predefined.py
+++ b/exoatlas/populations/predefined.py
@@ -10,7 +10,9 @@ class PredefinedPopulation(Population):
     label = "?"
     _expiration = 10 * u.day
 
-    def __init__(self, remake=False, standard=None, label=None, **plotkw):
+    def __init__(
+        self, remake=False, standard=None, label=None, verbose=False, **plotkw
+    ):
         """
         Initialize a predefined population.
 
@@ -34,10 +36,13 @@ class PredefinedPopulation(Population):
             object each time.
         label : str
             A custom label to apply to this population.
+        verbose : bool
+            Say where the data were loaded from?
         **plotkw : dict
             All other keywords are stored as plotting suggestions.
         """
 
+        self.verbose = verbose
         if standard is None:
             try:
                 # try to load the standardized table
@@ -130,6 +135,6 @@ class PredefinedPopulation(Population):
         read_kw = dict(format="ecsv", fill_values=[("", np.nan), ("--", np.nan)])
 
         standard = ascii.read(self._standardized_data_path, **read_kw)
-        print(f"Loaded standardized table from {self._standardized_data_path}")
-
+        if self.verbose:
+            print(f"Loaded standardized table from {self._standardized_data_path}")
         return standard

--- a/exoatlas/populations/solarsystem/minorplanets.py
+++ b/exoatlas/populations/solarsystem/minorplanets.py
@@ -6,14 +6,14 @@ from .sbdb_downloader import *
 class SolarSystemMinorPlanets(PredefinedPopulation):
     label = "Solar System Minor Planets"
 
-    def __init__(self, minimum_diameter=100 * u.km, **kw):
+    def __init__(self, minimum_diameter=10 * u.km, **kw):
         self.minimum_diameter = minimum_diameter
         self._downloader = SBDBDownloader(minimum_diameter=minimum_diameter)
         PredefinedPopulation.__init__(self, **kw)
 
         self.color = "midnightblue"
         self.zorder = 1
-        self.s = 20
+        self.s = 4
         self.respond_to_color = False
         self.exact = True
         self.marker = "s"
@@ -79,6 +79,9 @@ class SolarSystemMinorPlanets(PredefinedPopulation):
         s["stellar_radius"] = 1 * u.Rsun
         s["stellar_mass"] = 1 * u.Msun
         s["stellar_age"] = 4.5 * u.Gyr
+        s["distance"] = np.nan * u.pc
+        s["ra"] = np.nan * 0.0 * u.deg
+        s["dec"] = np.nan * 0.0 * u.deg
 
         # for k in ["mass", "radius"]:
         #    for side in ["lower", "upper"]:

--- a/exoatlas/populations/solarsystem/moons.py
+++ b/exoatlas/populations/solarsystem/moons.py
@@ -27,7 +27,7 @@ class SolarSystemMoons(PredefinedPopulation):
         PredefinedPopulation.__init__(self, **kwargs)
         self.color = "mediumblue"
         self.zorder = None
-        self.s = 20
+        self.s = 16
         self.respond_to_color = False
         self.exact = True
         self.marker = "s"
@@ -73,7 +73,9 @@ class SolarSystemMoons(PredefinedPopulation):
         for k in ["mass", "radius", "teff", "age"]:
             s[f"stellar_{k}"] = solar.get(f"stellar_{k}")[0]
         s["hostname"] = "Sun"
-
+        s["distance"] = np.nan * u.pc
+        s["ra"] = np.nan * 0.0 * u.deg
+        s["dec"] = np.nan * 0.0 * u.deg
         # get orbit properties from the Solar System planet hosts
         planets = solar.standard["name", "period", "semimajoraxis"]
         planets.columns[0].name = "planet"

--- a/exoatlas/populations/solarsystem/planets.py
+++ b/exoatlas/populations/solarsystem/planets.py
@@ -21,7 +21,7 @@ class SolarSystem(PredefinedPopulation):
         PredefinedPopulation.__init__(self, **kwargs)
         self.color = "cornflowerblue"
         self.zorder = 1e10
-        self.s = 80
+        self.s = 64
         self.respond_to_color = False
         self.exact = True
         self.marker = "s"
@@ -142,7 +142,7 @@ class SolarSystemDwarfPlanets(SolarSystem):
         """
         PredefinedPopulation.__init__(self, **kwargs)
         self.color = "royalblue"
-        self.s = 40
+        self.s = 32
         self.respond_to_color = False
         self.exact = True
         self.marker = "s"

--- a/exoatlas/version.py
+++ b/exoatlas/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 
 def version():

--- a/exoatlas/visualizations/galleries/GridGallery.py
+++ b/exoatlas/visualizations/galleries/GridGallery.py
@@ -16,11 +16,13 @@ class GridGallery(Gallery):
     def setup_maps(self, rows=[], cols=[], map_type=BubbleMap, **kw):
 
         # create the subplots
-
+        nrows, ncols = len(rows), len(cols)
         figsize = (self.mapsize[0] * len(cols), self.mapsize[1] * len(rows))
         self.fi, self.ax = self.create_subplots(
-            nrows=len(rows), ncols=len(cols), figsize=figsize, **kw
+            nrows=nrows, ncols=ncols, figsize=figsize, **kw
         )
+
+        self.ax = np.atleast_2d(self.ax).reshape((nrows, ncols))
 
         # attach maps to each ax
         self.maps = {}

--- a/exoatlas/visualizations/galleries/preset_galleries.py
+++ b/exoatlas/visualizations/galleries/preset_galleries.py
@@ -23,12 +23,14 @@ class PlanetGallery(Gallery):
         # attach maps to each ax
         self.maps = {}
         self.maps["flux_x_radius"] = Flux_x_Radius(ax=self.ax[1, 1])
+        # ErrorMap( xaxis=Flux, yaxis=Radius, ax=self.ax[1, 1])  #
         self.maps["mass_x_radius"] = Mass_x_Radius(ax=self.ax[1, 0])
         self.maps["flux_x_escape"] = Flux_x_EscapeVelocity(ax=self.ax[0, 1])
+        # ErrorMap(xaxis=Flux, yaxis=EscapeVelocity, ax=self.ax[0, 1])
         self.maps["radius_x_radius"] = StellarRadius_x_PlanetRadius(ax=self.ax[1, 2])
-        self.maps["mass_x_escape"] = BubbleMap(
-            xaxis=Mass, yaxis=EscapeVelocity, ax=self.ax[0, 0]
-        )
+        # ErrorMap(xaxis=StellarRadius, yaxis=Radius, ax=self.ax[1, 2])  #
+        self.maps["mass_x_escape"] = Mass_x_EscapeVelocity(ax=self.ax[0, 0])
+        # ErrorMap(xaxis=Mass, yaxis=EscapeVelocity, ax=self.ax[0, 0])
 
     def refine_maps(self):
         """
@@ -122,6 +124,31 @@ class ObservableGallery(GridGallery):
 
         m = self.maps["relative_insolation_x_emission_signal"]
         add_size_explainer(ax=m.ax, label=m.plottable["size"].label, **kw)
+
+
+class EverythingGallery(GridGallery):
+    def __init__(self):
+        GridGallery.__init__(
+            self,
+            cols=[Flux(lim=[5e4, 2e-5])],
+            rows=[
+                Radius(lim=[0.01, 30]),
+                Mass(lim=[0.0001, 4100]),
+                EscapeVelocity(lim=[0.01, 1e3]),
+                Density,
+                Depth(lim=[1e-8, 1]),
+                Transmission(lim=[1e-8, 1]),
+                Emission(lim=[1e-8, 1], wavelength=5 * u.micron),
+                Distance,
+            ],
+            # StellarBrightness(telescope_name='JWST', wavelength=1*u.micron)],
+            map_type=ErrorMap,
+            mapsize=(7, 2),
+        )
+
+    def refine_maps(self):
+        GridGallery.refine_maps(self)
+        self.maps["relative_insolation_x_radius"].add_legend(fontsize=5)
 
 
 '''class ObservableGallery(BuildablePlot):

--- a/exoatlas/visualizations/maps/ErrorMap.py
+++ b/exoatlas/visualizations/maps/ErrorMap.py
@@ -195,6 +195,7 @@ class ErrorMap(BubbleMap):
                     **kw,
                 )
 
+            fake_errorbar = plt.errorbar([], [], [], color=color, label=self.pop.label)
         # set the scales, limits, labels
         self.refine_axes()
 

--- a/exoatlas/visualizations/maps/Map.py
+++ b/exoatlas/visualizations/maps/Map.py
@@ -403,7 +403,7 @@ class Map:
             if getattr(self.pop, "zorder", None) is not None:
                 kw["zorder"] = self.pop.zorder
             kw.update(**getattr(self.pop, "annotate_kw", {}))
-            self.annotate_planets(self.pop, **kw)
+            self.annotate_planets(self.pop_key, **kw)
 
     def annotate_planets(self, pop, before="\n", after="", restrictlimits=False, **kw):
         """
@@ -455,6 +455,7 @@ class Map:
                 color=self.pop.color,
                 alpha=self.pop.alpha,
                 clip_on=True,
+                zorder=self.pop.zorder,
             )
 
             # think this is just as Python 3 thing

--- a/exoatlas/visualizations/maps/preset_maps.py
+++ b/exoatlas/visualizations/maps/preset_maps.py
@@ -6,7 +6,7 @@ from .BubbleMap import *
 from .ErrorMap import *
 
 
-class Flux_x_Radius(BubbleMap):
+class Flux_x_Radius(ErrorMap):
     xaxis = Flux
     yaxis = Radius
 
@@ -85,10 +85,6 @@ class Flux_x_Radius(BubbleMap):
 
         # Teff_inner = 5780
         # Teff_outer = 2600
-
-
-class Flux_x_Mass(Flux_x_Radius):
-    yaxis = KludgedMass
 
 
 class Flux_x_Teff(BubbleMap):
@@ -195,7 +191,7 @@ class Density_x_Radius(BubbleMap):
     yaxis = Radius
 
 
-class StellarRadius_x_PlanetRadius(BubbleMap):
+class StellarRadius_x_PlanetRadius(ErrorMap):
     xaxis = StellarRadius
     yaxis = Radius
 
@@ -309,12 +305,17 @@ class Mass_x_Radius(ErrorMap):
             )
 
 
-class Flux_x_EscapeVelocity(BubbleMap):
+class Mass_x_EscapeVelocity(ErrorMap):
+    xaxis = Mass
+    yaxis = EscapeVelocity
+
+
+class Flux_x_EscapeVelocity(ErrorMap):
     xaxis = Flux
     yaxis = EscapeVelocity
 
     def plot_constant_lambda(
-        self, alpha=0.5, color="gray", x=0.01, y=100, rotation=-4.5, **kw
+        self, alpha=0.5, color="gray", x=0.01, y=100, rotation=-4.5, zorder=-100, **kw
     ):
         """
         Plot the escape velocity vs insolation for
@@ -364,6 +365,7 @@ class Flux_x_EscapeVelocity(BubbleMap):
                 escape_velocity(teq, lam=lam),
                 color=color,
                 alpha=alpha,
+                zorder=zorder,
                 **kw
             )
 


### PR DESCRIPTION
This pull request makes some minor changes to help put together a poster. The main new things it introduces are:
- `get_all_planets` to get all Solar System and exoplanets in one dictionary (split by whether transiting) 
- `EverythingGallery` to compare all planet populations in one hilariously tall plot