### PR TITLE
Update curating.ipynb

### DIFF
--- a/docs/user/curating.ipynb
+++ b/docs/user/curating.ipynb
@@ -156,7 +156,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "e[\"HD189733\"].radius"
+    "e[\"HD189733\"].radius()"
    ]
   },
   {


### PR DESCRIPTION
Missing `()`after `.radius  ` to show the updated radius value in the user guide. (159)